### PR TITLE
Add  IPC for camera plugin

### DIFF
--- a/vm_shared/models/camera/camera.sdf
+++ b/vm_shared/models/camera/camera.sdf
@@ -34,6 +34,7 @@
             <always_on>1</always_on>
             <update_rate>10</update_rate>
             <visualize>true</visualize>
+            <plugin name="sensor_ipc" filename="libsensor_ipc.so"/>
         </sensor>
         </link>
     </model>

--- a/vm_shared/src/CMakeLists.txt
+++ b/vm_shared/src/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 add_subdirectory(plugin_hw)
 add_subdirectory(move_model_hw)
 add_subdirectory(opencv_ipc)
+add_subdirectory(sensor_ipc)
 
 
 # include what you see and others:

--- a/vm_shared/src/common.hpp
+++ b/vm_shared/src/common.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace GazeboIPC {
+    const char* const CamereMutexName = "CameraImageMutex"; 
+    const char* const NamedSharedMemName = "CameraImage"; 
+}

--- a/vm_shared/src/opencv_ipc/CMakeLists.txt
+++ b/vm_shared/src/opencv_ipc/CMakeLists.txt
@@ -9,10 +9,13 @@ target_include_directories(cv_hw
         ${OpenCV_INCLUDE_DIRS}
 )
 
+find_package(Threads REQUIRED)
+
 target_link_libraries(cv_hw
     PRIVATE
         ${OpenCV_LIBS}
         rt
+        Threads::Threads
 )
 
 target_compile_features(cv_hw

--- a/vm_shared/src/opencv_ipc/main.cpp
+++ b/vm_shared/src/opencv_ipc/main.cpp
@@ -5,6 +5,8 @@
 #include <boost/interprocess/sync/named_mutex.hpp>
 #include <opencv4/opencv2/opencv.hpp>
 
+#include "../common.hpp"
+
 namespace ipc = boost::interprocess;
 
 int main()
@@ -14,10 +16,8 @@ int main()
     // test interprocess communication
     ipc::shared_memory_object shdmem{
         ipc::open_only,
-        "CameraImage",
+        GazeboIPC::NamedSharedMemName,
         ipc::read_only};
-
-    // shdmem.truncate(921600);
 
     std::cout << shdmem.get_name() << std::endl;
 
@@ -28,7 +28,7 @@ int main()
     }
 
     ipc::mapped_region region{shdmem, ipc::read_only};
-    ipc::named_mutex mutex{ipc::open_or_create, "CameraImageMutex"};
+    ipc::named_mutex mutex{ipc::open_or_create, GazeboIPC::CamereMutexName};
 
     while (true) {
         {
@@ -41,7 +41,7 @@ int main()
         cv::waitKey(40);
     }
 
-    ipc::named_mutex::remove("CameraImageMutex");
+    ipc::named_mutex::remove(GazeboIPC::CamereMutexName);
 
     return 0;
 }

--- a/vm_shared/src/opencv_ipc/main.cpp
+++ b/vm_shared/src/opencv_ipc/main.cpp
@@ -1,6 +1,8 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
 #include <opencv4/opencv2/opencv.hpp>
 
 namespace ipc = boost::interprocess;
@@ -11,11 +13,11 @@ int main()
 
     // test interprocess communication
     ipc::shared_memory_object shdmem{
-        ipc::open_or_create,
-        "Boost",
-        ipc::read_write};
+        ipc::open_only,
+        "CameraImage",
+        ipc::read_only};
 
-    shdmem.truncate(1024);
+    // shdmem.truncate(921600);
 
     std::cout << shdmem.get_name() << std::endl;
 
@@ -25,12 +27,21 @@ int main()
         std::cout << "size: " << size << std::endl;
     }
 
-    ipc::mapped_region region{shdmem, ipc::read_write};
+    ipc::mapped_region region{shdmem, ipc::read_only};
+    ipc::named_mutex mutex{ipc::open_or_create, "CameraImageMutex"};
 
-    // test opencv with gui
-    cv::Mat im(480, 640, CV_8UC1, cv::Scalar(45));
-    cv::imshow("Dark", im);
-    cv::waitKey(0);
+    while (true) {
+        {
+            ipc::scoped_lock<ipc::named_mutex> lock{mutex};
+            unsigned char *mem = static_cast<unsigned char*>(region.get_address());
+            // TODO read dimension from shared memory
+            cv::Mat im{480, 640, CV_8UC3, mem};
+            cv::imshow("OpenCV IPC: CameraImage", im);
+        }
+        cv::waitKey(40);
+    }
+
+    ipc::named_mutex::remove("CameraImageMutex");
 
     return 0;
 }

--- a/vm_shared/src/sensor_ipc/CMakeLists.txt
+++ b/vm_shared/src/sensor_ipc/CMakeLists.txt
@@ -3,8 +3,14 @@ include_directories(${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
 
-add_library(sensor_ipc SHARED sensorIPC.cc)
-target_link_libraries(sensor_ipc ${GAZEBO_LIBRARIES})
+find_package(Threads REQUIRED)
+
+add_library(sensor_ipc SHARED sensorIPC.cpp)
+target_link_libraries(sensor_ipc 
+    PRIVATE 
+        ${GAZEBO_LIBRARIES} 
+        CameraPlugin
+        Threads::Threads )
 
 install(
     TARGETS

--- a/vm_shared/src/sensor_ipc/sensorIPC.cpp
+++ b/vm_shared/src/sensor_ipc/sensorIPC.cpp
@@ -1,0 +1,56 @@
+#include "gazebo/gazebo.hh"
+#include "gazebo/plugins/CameraPlugin.hh"
+
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+namespace ipc = boost::interprocess;
+
+#include <cstring>
+
+namespace gazebo
+{
+  class CameraIPC : public CameraPlugin
+  {
+    public: 
+    
+    CameraIPC() : CameraPlugin(), 
+        shdmem{ipc::open_or_create,
+            "CameraImage",
+            ipc::read_write},
+        mutex{ipc::open_or_create, "CameraImageMutex"},
+        region{this->shdmem, ipc::read_write},
+        size{0}
+    { }
+
+    void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
+    {
+        CameraPlugin::Load(_parent, _sdf);
+        this->size = this->width * this->height * this->depth;
+        shdmem.truncate(this->size);
+    }
+
+    void OnNewFrame(const unsigned char *image,
+        unsigned int width, unsigned int height, unsigned int depth,
+        const std::string &format)
+    {
+        // TODO: add timestamp
+        ipc::scoped_lock<ipc::named_mutex> lock{this->mutex};
+        std::memcpy(region.get_address(), image, this->size);
+    }
+
+    virtual ~CameraIPC() {
+        ipc::named_mutex::remove("CameraImageMutex");
+    }
+
+    ipc::shared_memory_object shdmem;
+    ipc::mapped_region region;
+    ipc::named_mutex mutex;
+    unsigned int size;
+  };
+
+  // Register this plugin with the simulator
+  GZ_REGISTER_SENSOR_PLUGIN(CameraIPC)
+}


### PR DESCRIPTION
This PR adds functionality to get the image from gazebo into another process. 

Test Plan
1. Run gazebo
2. Start opencv IPC: opencv_ipc/cv_hw.

Start simulation.